### PR TITLE
Depend on autoloading

### DIFF
--- a/library/Zend/Uri.php
+++ b/library/Zend/Uri.php
@@ -132,14 +132,6 @@ abstract class Zend_Uri
             }
         }
 
-        // require_once 'Zend/Loader.php';
-        try {
-            Zend_Loader::loadClass($className);
-        } catch (Exception $e) {
-            // require_once 'Zend/Uri/Exception.php';
-            throw new Zend_Uri_Exception("\"$className\" not found");
-        }
-
         $schemeHandler = new $className($scheme, $schemeSpecific);
 
         if (! $schemeHandler instanceof Zend_Uri) {


### PR DESCRIPTION
Remove calls to Zend_Loader because we have autoloading and Zend_Loader can never load this file. 
